### PR TITLE
リファクタリング

### DIFF
--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -12,8 +12,8 @@ const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remark
 
 const Article = ({
   article, articlesLength, index,
-  deleteArticle, addComment, deleteComment, handleChange,
-  stateMe, stateComment
+  deleteArticle, deleteComment,
+  stateMe
 }) => {
   const imageIndex = ((articlesLength - index) % 45) + 1;
   const imagePath = `images/${imageIndex}.gif`;

--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -7,61 +7,76 @@ import remarkExternalLinks from 'remark-external-links'
 import ExpandCollapse from 'react-expand-collapse';
 import CommentList from '../Comment/CommentList'
 import CommentForm from '../Comment/CommentForm'
+import {db} from '../../js/firebase';
 
 const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remarkExternalLinks);
+const dbCollectionArticles = db.collection("messages");
 
-const Article = ({
-  article, articlesLength, index,
-  deleteArticle,
-  stateMe
-}) => {
-  const imageIndex = ((articlesLength - index) % 45) + 1;
-  const imagePath = `images/${imageIndex}.gif`;
-  const created = article.created ?
-    DayJS.unix(article.created.seconds).format('YYYY-MM-DD HH:mm:ss') :
-    DayJS(new Date()).format('YYYY-MM-DD HH:mm:ss');
-  const deleteButton = article.uid === stateMe.uid ?
-    <button value={article.id} className="moya__delete_link" onClick={deleteArticle}>[削除]</button> :
-    null
-  const content = remarkProcessor.processSync(article.message).contents
+class Article extends React.Component {
+  deleteArticle = (e) => {
+    if(window.confirm('本当に削除しますか？')){
+      dbCollectionArticles.doc(e.target.value).delete().then(function() {
+        console.log("Document successfully deleted!");
+      }).catch(function(error) {
+        console.error("Error removeing document: ", error);
+      });
+    }
+  }
 
-  return (
-    <div key={index} className="nes-container is-dark with-title moya__article">
-      <div className="title moya__title">
-        {article.displayName}
-      </div>
-      <div className="moya__content">
-        <div className="moya__user_image_container">
-          <img src={imagePath} className="moya__user_image" alt="icon"/>
+  render() {
+    const article = this.props.article;
+    const articlesLength = this.props.articlesLength;
+    const index = this.props.index;
+    const stateMe = this.props.stateMe;
+
+    const imageIndex = ((articlesLength - index) % 45) + 1;
+    const imagePath = `images/${imageIndex}.gif`;
+    const created = article.created ?
+      DayJS.unix(article.created.seconds).format('YYYY-MM-DD HH:mm:ss') :
+      DayJS(new Date()).format('YYYY-MM-DD HH:mm:ss');
+    const deleteButton = article.uid === stateMe.uid ?
+      <button value={article.id} className="moya__delete_link" onClick={this.deleteArticle}>[削除]</button> :
+      null
+    const content = remarkProcessor.processSync(article.message).contents
+
+    return (
+      <div key={index} className="nes-container is-dark with-title moya__article">
+        <div className="title moya__title">
+          {article.displayName}
         </div>
-        <div className="moya__content_text">
-          <ExpandCollapse
-            previewHeight="480px"
-            expandText="続きを読む"
-            collapseText="閉じる"
-            ellipsis={false}
-          >
-            {content}
-          </ExpandCollapse>
-          <div className="moya__datetime">
-            {created}
-            {deleteButton}
+        <div className="moya__content">
+          <div className="moya__user_image_container">
+            <img src={imagePath} className="moya__user_image" alt="icon"/>
+          </div>
+          <div className="moya__content_text">
+            <ExpandCollapse
+              previewHeight="480px"
+              expandText="続きを読む"
+              collapseText="閉じる"
+              ellipsis={false}
+            >
+              {content}
+            </ExpandCollapse>
+            <div className="moya__datetime">
+              {created}
+              {deleteButton}
+            </div>
           </div>
         </div>
+        <div className="moya__comments">
+          <CommentList
+            comments={article.comments}
+            articleId={article.id}
+            stateMe={stateMe}
+          />
+          <CommentForm
+            article={article}
+            stateMe={stateMe}
+          />
+        </div>
       </div>
-      <div className="moya__comments">
-        <CommentList
-          comments={article.comments}
-          articleId={article.id}
-          stateMe={stateMe}
-        />
-        <CommentForm
-          article={article}
-          stateMe={stateMe}
-        />
-      </div>
-    </div>
-  )
+    )
+  }
 }
 
 export default Article

--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -12,7 +12,7 @@ const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remark
 
 const Article = ({
   article, articlesLength, index,
-  deleteArticle, deleteComment,
+  deleteArticle,
   stateMe
 }) => {
   const imageIndex = ((articlesLength - index) % 45) + 1;
@@ -53,7 +53,6 @@ const Article = ({
         <CommentList
           comments={article.comments}
           articleId={article.id}
-          deleteComment={deleteComment}
           stateMe={stateMe}
         />
         <CommentForm

--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -13,14 +13,14 @@ const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remark
 const Article = ({
   article, articlesLength, index,
   deleteArticle, addComment, deleteComment, handleChange,
-  stateMeUid, stateMe, stateComment
+  stateMe, stateComment
 }) => {
   const imageIndex = ((articlesLength - index) % 45) + 1;
   const imagePath = `images/${imageIndex}.gif`;
   const created = article.created ?
     DayJS.unix(article.created.seconds).format('YYYY-MM-DD HH:mm:ss') :
     DayJS(new Date()).format('YYYY-MM-DD HH:mm:ss');
-  const deleteButton = article.uid === stateMeUid ?
+  const deleteButton = article.uid === stateMe.uid ?
     <button value={article.id} className="moya__delete_link" onClick={deleteArticle}>[削除]</button> :
     null
   const content = remarkProcessor.processSync(article.message).contents
@@ -54,7 +54,7 @@ const Article = ({
           comments={article.comments}
           articleId={article.id}
           deleteComment={deleteComment}
-          stateMeUid={stateMeUid}
+          stateMe={stateMe}
         />
         <CommentForm
           article={article}

--- a/src/components/Article/Article.js
+++ b/src/components/Article/Article.js
@@ -13,7 +13,7 @@ const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remark
 const Article = ({
   article, articlesLength, index,
   deleteArticle, addComment, deleteComment, handleChange,
-  stateMeUid, stateComment
+  stateMeUid, stateMe, stateComment
 }) => {
   const imageIndex = ((articlesLength - index) % 45) + 1;
   const imagePath = `images/${imageIndex}.gif`;
@@ -58,9 +58,7 @@ const Article = ({
         />
         <CommentForm
           article={article}
-          addComment={addComment}
-          handleChange={handleChange}
-          stateComment={stateComment}
+          stateMe={stateMe}
         />
       </div>
     </div>

--- a/src/components/Article/ArticleForm.js
+++ b/src/components/Article/ArticleForm.js
@@ -7,20 +7,16 @@ const dbCollectionArticles = db.collection("messages");
 class ArticleForm extends React.Component {
   constructor() {
     super();
-    this.state = {
-      article: ''
-    }
+    this.input = React.createRef();
   }
 
   addArticle = (e) => {
     e.preventDefault();
+    const article = this.input.current.value;
 
-    const article = this.state.article
     if (!article) { return; }
-
-    this._clearState('article');
-    this._clearArticleTextarea();
     this._focusSubmit();
+    this.input.current.value = '';
 
     const ref = dbCollectionArticles.doc();
     ref.set({
@@ -36,24 +32,9 @@ class ArticleForm extends React.Component {
     });
   }
 
-  handleChange = (e) => {
-    const t = e.target;
-    this.state.article = t.value;
-  }
-
   // Private Methods
     _focusSubmit() {
       document.getElementById('submit').focus();
-    }
-
-    _clearState(key) {
-      this.setState({[key]: ''}, () => {
-        this.setState({[key]: undefined});
-      });
-    }
-
-    _clearArticleTextarea() {
-      document.getElementById('article').value = '';
     }
 
   render() {
@@ -64,11 +45,11 @@ class ArticleForm extends React.Component {
           id="article"
           className="moya__article__textarea"
           placeholder="最近の出来事を共有..."
-          onChange={this.handleChange}
           name="article"
+          inputRef={this.input}
         />
         <div className="moya__form__submit">
-          <button type="submit" id="submit" onClick={this.addArticle}>Submit</button>
+          <button type="submit" id="submit">Submit</button>
         </div>
       </form>
     )

--- a/src/components/Article/ArticleForm.js
+++ b/src/components/Article/ArticleForm.js
@@ -1,26 +1,78 @@
 import React from 'react'
 import Textarea from 'react-textarea-autosize';
+import {db, fieldValue} from '../../js/firebase';
 
-const ArticleForm = ({
-  addArticle, handleChange,
-  stateArticle
-}) => {
-  return (
-    <form autoComplete="off" className="moya__form" onSubmit={addArticle}>
-      <Textarea
-        minRows={3}
-        id="article"
-        className="moya__article__textarea"
-        placeholder="最近の出来事を共有..."
-        onChange={handleChange}
-        name="article"
-        value={stateArticle}
-      />
-      <div className="moya__form__submit">
-        <button type="submit" id="submit" onClick={addArticle}>Submit</button>
-      </div>
-    </form>
-  )
+const dbCollectionArticles = db.collection("messages");
+
+class ArticleForm extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      article: ''
+    }
+  }
+
+  addArticle = (e) => {
+    e.preventDefault();
+
+    const article = this.state.article
+    if (!article) { return; }
+
+    this._clearState('article');
+    this._clearArticleTextarea();
+    this._focusSubmit();
+
+    const ref = dbCollectionArticles.doc();
+    ref.set({
+      message: article,
+      created: fieldValue.serverTimestamp(),
+      updated: fieldValue.serverTimestamp(),
+      uid: this.props.stateMe ? this.props.stateMe.uid : 'nobody',
+      displayName: this.props.stateMe ? this.props.stateMe.displayName : 'noname'
+    }).then(function(docRef) {
+      console.log(docRef);
+    }).catch(function(error) {
+      console.error("Error adding document: ", error);
+    });
+  }
+
+  handleChange = (e) => {
+    const t = e.target;
+    this.state.article = t.value;
+  }
+
+  // Private Methods
+    _focusSubmit() {
+      document.getElementById('submit').focus();
+    }
+
+    _clearState(key) {
+      this.setState({[key]: ''}, () => {
+        this.setState({[key]: undefined});
+      });
+    }
+
+    _clearArticleTextarea() {
+      document.getElementById('article').value = '';
+    }
+
+  render() {
+    return (
+      <form autoComplete="off" className="moya__form" onSubmit={this.addArticle}>
+        <Textarea
+          minRows={3}
+          id="article"
+          className="moya__article__textarea"
+          placeholder="最近の出来事を共有..."
+          onChange={this.handleChange}
+          name="article"
+        />
+        <div className="moya__form__submit">
+          <button type="submit" id="submit" onClick={this.addArticle}>Submit</button>
+        </div>
+      </form>
+    )
+  }
 }
 
 export default ArticleForm

--- a/src/components/Article/ArticleList.js
+++ b/src/components/Article/ArticleList.js
@@ -3,7 +3,7 @@ import Article from '../Article/Article'
 
 const ArticleList = ({
   articles,
-  deleteArticle, deleteComment,
+  deleteArticle,
   state, stateMe
 }) => {
   const articlesLength = articles.length;
@@ -17,7 +17,6 @@ const ArticleList = ({
           articlesLength={articlesLength}
           index={index}
           deleteArticle={deleteArticle}
-          deleteComment={deleteComment}
           stateMe={stateMe}
         />
       )

--- a/src/components/Article/ArticleList.js
+++ b/src/components/Article/ArticleList.js
@@ -4,7 +4,7 @@ import Article from '../Article/Article'
 const ArticleList = ({
   articles,
   deleteArticle, addComment, deleteComment, handleChange,
-  state, stateMeUid
+  state, stateMeUid, stateMe
 }) => {
   const articlesLength = articles.length;
 
@@ -21,6 +21,7 @@ const ArticleList = ({
           deleteComment={deleteComment}
           handleChange={handleChange}
           stateMeUid={stateMeUid}
+          stateMe={stateMe}
           stateComment={state[`comment-${article.id}`]}
         />
       )

--- a/src/components/Article/ArticleList.js
+++ b/src/components/Article/ArticleList.js
@@ -3,8 +3,7 @@ import Article from '../Article/Article'
 
 const ArticleList = ({
   articles,
-  deleteArticle,
-  state, stateMe
+  stateMe
 }) => {
   const articlesLength = articles.length;
 
@@ -16,7 +15,6 @@ const ArticleList = ({
           article={article}
           articlesLength={articlesLength}
           index={index}
-          deleteArticle={deleteArticle}
           stateMe={stateMe}
         />
       )

--- a/src/components/Article/ArticleList.js
+++ b/src/components/Article/ArticleList.js
@@ -4,7 +4,7 @@ import Article from '../Article/Article'
 const ArticleList = ({
   articles,
   deleteArticle, addComment, deleteComment, handleChange,
-  state, stateMeUid, stateMe
+  state, stateMe
 }) => {
   const articlesLength = articles.length;
 
@@ -20,7 +20,6 @@ const ArticleList = ({
           addComment={addComment}
           deleteComment={deleteComment}
           handleChange={handleChange}
-          stateMeUid={stateMeUid}
           stateMe={stateMe}
           stateComment={state[`comment-${article.id}`]}
         />

--- a/src/components/Article/ArticleList.js
+++ b/src/components/Article/ArticleList.js
@@ -3,7 +3,7 @@ import Article from '../Article/Article'
 
 const ArticleList = ({
   articles,
-  deleteArticle, addComment, deleteComment, handleChange,
+  deleteArticle, deleteComment,
   state, stateMe
 }) => {
   const articlesLength = articles.length;
@@ -17,11 +17,8 @@ const ArticleList = ({
           articlesLength={articlesLength}
           index={index}
           deleteArticle={deleteArticle}
-          addComment={addComment}
           deleteComment={deleteComment}
-          handleChange={handleChange}
           stateMe={stateMe}
-          stateComment={state[`comment-${article.id}`]}
         />
       )
     })

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -10,12 +10,12 @@ const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remark
 const Comment = ({
   comment, articleId,
   deleteComment,
-  stateMeUid
+  stateMe
 }) => {
   const created = comment.created ?
     DayJS.unix(comment.created.seconds).format('YYYY-MM-DD HH:mm:ss') :
     DayJS(new Date()).format('YYYY-MM-DD HH:mm:ss');
-  const deleteButton = comment.uid === stateMeUid ?
+  const deleteButton = comment.uid === stateMe.uid ?
     <button value={comment.id} data-article-id={articleId} className="moya__delete_link" onClick={deleteComment}>[削除]</button> :
     null
   const content = remarkProcessor.processSync(comment.message).contents

--- a/src/components/Comment/Comment.js
+++ b/src/components/Comment/Comment.js
@@ -5,44 +5,66 @@ import reactRenderer from 'remark-react'
 import remarkBreaks from 'remark-breaks'
 import remarkExternalLinks from 'remark-external-links'
 import ExpandCollapse from 'react-expand-collapse';
+import {db, fieldValue} from '../../js/firebase';
 const remarkProcessor = remark().use(reactRenderer).use(remarkBreaks).use(remarkExternalLinks);
+const dbCollectionArticles = db.collection("messages");
+const dbCollectionComments = db.collection("comments");
 
-const Comment = ({
-  comment, articleId,
-  deleteComment,
-  stateMe
-}) => {
-  const created = comment.created ?
-    DayJS.unix(comment.created.seconds).format('YYYY-MM-DD HH:mm:ss') :
-    DayJS(new Date()).format('YYYY-MM-DD HH:mm:ss');
-  const deleteButton = comment.uid === stateMe.uid ?
-    <button value={comment.id} data-article-id={articleId} className="moya__delete_link" onClick={deleteComment}>[削除]</button> :
-    null
-  const content = remarkProcessor.processSync(comment.message).contents
+class Comment extends React.Component {
+  deleteComment = (e) => {
+    if(window.confirm('本当に削除しますか？')){
+      const commentId = e.target.value;
+      const articleId = e.target.dataset.articleId;
+      const article = dbCollectionArticles.doc(articleId);
+      const comment = dbCollectionComments.doc(commentId);
 
-  return (
-    <div className="moya__comment">
-      <div className="moya__comment__header">
-        <div className="moya__comment__title">{comment.displayName}</div>
-        <div className="moya__comment__datetime">
-          {created}
-          {deleteButton}
+      comment.delete().then(function() {
+        article.update({
+          deletedCommentAt: fieldValue.serverTimestamp()
+        }).then(function(docRef) {
+          console.log(docRef);
+        }).catch(function(error) {
+          console.error("Error update document: ", error);
+        });
+      }).catch(function(error) {
+        console.error("Error removeing comment: ", error);
+      });
+    }
+  }
+
+  render() {
+    const created = this.props.comment.created ?
+      DayJS.unix(this.props.comment.created.seconds).format('YYYY-MM-DD HH:mm:ss') :
+      DayJS(new Date()).format('YYYY-MM-DD HH:mm:ss');
+    const deleteButton = this.props.comment.uid === this.props.stateMe.uid ?
+      <button value={this.props.comment.id} data-article-id={this.props.articleId} className="moya__delete_link" onClick={this.deleteComment}>[削除]</button> :
+      null
+    const content = remarkProcessor.processSync(this.props.comment.message).contents
+
+    return (
+      <div className="moya__comment">
+        <div className="moya__comment__header">
+          <div className="moya__comment__title">{this.props.comment.displayName}</div>
+          <div className="moya__comment__datetime">
+            {created}
+            {deleteButton}
+          </div>
+        </div>
+        <div className="moya__comment__content">
+          <div className="moya__comment__content__body">
+            <ExpandCollapse
+              previewHeight="320px"
+              expandText="続きを読む"
+              collapseText="閉じる"
+              ellipsis={false}
+            >
+              {content}
+            </ExpandCollapse>
+          </div>
         </div>
       </div>
-      <div className="moya__comment__content">
-        <div className="moya__comment__content__body">
-          <ExpandCollapse
-            previewHeight="320px"
-            expandText="続きを読む"
-            collapseText="閉じる"
-            ellipsis={false}
-          >
-            {content}
-          </ExpandCollapse>
-        </div>
-      </div>
-    </div>
-  )
+    )
+  }
 }
 
 export default Comment

--- a/src/components/Comment/CommentForm.js
+++ b/src/components/Comment/CommentForm.js
@@ -1,29 +1,91 @@
 import React from 'react'
 import Textarea from 'react-textarea-autosize';
+import {db, fieldValue} from '../../js/firebase';
 
-const CommentForm = ({
-  article,
-  addComment, handleChange,
-  stateComment
-}) => {
-  const name = `comment-${article.id}`
+const dbCollectionArticles = db.collection("messages");
+const dbCollectionComments = db.collection("comments");
 
-  return (
-    <form autoComplete="off" className="moya__comment__form" onSubmit={addComment}>
-      <Textarea
-        minRows={1}
-        id="message"
-        className="moya_comment_message"
-        placeholder="コメントを追加..."
-        onChange={handleChange}
-        name={name}
-        value={stateComment}
-      />
-      <div className="moya__comment__form__submit">
-        <button type="submit" data-article-id={article.id} onClick={addComment}>Submit</button>
-      </div>
-    </form>
-  )
+class CommentForm extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      comment: ''
+    }
+  }
+
+  addComment = (e) => {
+    e.preventDefault();
+
+    const articleId = e.target.dataset.articleId;
+    const textareaId = e.target.dataset.textareaId;
+    const comment = this.state.comment;
+    if (!comment) { return; }
+
+    console.log(e.target);
+    this._clearState('comment');
+    this._clearCommentTextarea(textareaId);
+
+    const article = dbCollectionArticles.doc(articleId);
+    const ref = dbCollectionComments.doc();
+
+    ref.set({
+      articleId: articleId,
+      message: comment,
+      created: fieldValue.serverTimestamp(),
+      uid: this.props.stateMe ? this.props.stateMe.uid : 'nobody',
+      displayName: this.props.stateMe ? this.props.stateMe.displayName : 'noname'
+    }).then(function(docRef) {
+      article.update({
+        updated: fieldValue.serverTimestamp()
+      }).then(function(docRef) {
+        console.log(docRef);
+      }).catch(function(error) {
+        console.error("Error update document: ", error);
+      });
+    }).catch(function(error) {
+      console.error("Error adding document: ", error);
+    });
+  }
+
+  handleChange = (e) => {
+    const t = e.target;
+    this.state.comment = t.value;
+  }
+
+  // Private Methods
+    _clearState(key) {
+      this.setState({[key]: ''}, () => {
+        this.setState({[key]: undefined});
+      });
+    }
+
+    _clearCommentTextarea(textareaId) {
+      document.getElementById(textareaId).value = '';
+    }
+
+  render() {
+    const textareaName = `comment-${this.props.article.id}`
+
+    return (
+      <form autoComplete="off" className="moya__comment__form"
+        data-article-id={this.props.article.id}
+        data-textarea-id={textareaName}
+        onSubmit={this.addComment}
+      >
+        <Textarea
+          minRows={1}
+          id={textareaName}
+          className="moya_comment_message"
+          placeholder="コメントを追加..."
+          onChange={this.handleChange}
+          name={textareaName}
+        />
+        <div className="moya__comment__form__submit">
+          <button type="submit">Submit</button>
+        </div>
+      </form>
+    )
+  }
 }
 
 export default CommentForm

--- a/src/components/Comment/CommentForm.js
+++ b/src/components/Comment/CommentForm.js
@@ -8,22 +8,16 @@ const dbCollectionComments = db.collection("comments");
 class CommentForm extends React.Component {
   constructor() {
     super();
-    this.state = {
-      comment: ''
-    }
+    this.input = React.createRef();
   }
 
   addComment = (e) => {
     e.preventDefault();
 
     const articleId = e.target.dataset.articleId;
-    const textareaId = e.target.dataset.textareaId;
-    const comment = this.state.comment;
+    const comment = this.input.current.value;
     if (!comment) { return; }
-
-    console.log(e.target);
-    this._clearState('comment');
-    this._clearCommentTextarea(textareaId);
+    this.input.current.value = '';
 
     const article = dbCollectionArticles.doc(articleId);
     const ref = dbCollectionComments.doc();
@@ -47,38 +41,18 @@ class CommentForm extends React.Component {
     });
   }
 
-  handleChange = (e) => {
-    const t = e.target;
-    this.state.comment = t.value;
-  }
-
-  // Private Methods
-    _clearState(key) {
-      this.setState({[key]: ''}, () => {
-        this.setState({[key]: undefined});
-      });
-    }
-
-    _clearCommentTextarea(textareaId) {
-      document.getElementById(textareaId).value = '';
-    }
-
   render() {
     const textareaName = `comment-${this.props.article.id}`
 
     return (
-      <form autoComplete="off" className="moya__comment__form"
-        data-article-id={this.props.article.id}
-        data-textarea-id={textareaName}
-        onSubmit={this.addComment}
-      >
+      <form autoComplete="off" className="moya__comment__form" data-article-id={this.props.article.id} onSubmit={this.addComment}>
         <Textarea
           minRows={1}
           id={textareaName}
           className="moya_comment_message"
           placeholder="コメントを追加..."
-          onChange={this.handleChange}
           name={textareaName}
+          inputRef={this.input}
         />
         <div className="moya__comment__form__submit">
           <button type="submit">Submit</button>

--- a/src/components/Comment/CommentList.js
+++ b/src/components/Comment/CommentList.js
@@ -4,7 +4,7 @@ import Comment from '../Comment/Comment'
 const CommentList = ({
   comments, articleId,
   deleteComment,
-  stateMeUid
+  stateMe
 }) => (
   <div>
     {comments.map(comment =>
@@ -13,7 +13,7 @@ const CommentList = ({
         comment={comment}
         articleId={articleId}
         deleteComment={deleteComment}
-        stateMeUid={stateMeUid}
+        stateMe={stateMe}
       />
     )}
   </div>

--- a/src/components/Comment/CommentList.js
+++ b/src/components/Comment/CommentList.js
@@ -3,7 +3,6 @@ import Comment from '../Comment/Comment'
 
 const CommentList = ({
   comments, articleId,
-  deleteComment,
   stateMe
 }) => (
   <div>
@@ -12,7 +11,6 @@ const CommentList = ({
         key={comment.id}
         comment={comment}
         articleId={articleId}
-        deleteComment={deleteComment}
         stateMe={stateMe}
       />
     )}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,21 +1,28 @@
 import React from 'react'
+import {auth, provider} from '../js/firebase';
 
-const Header = ({
-  login,
-  logout,
-  stateMe
-}) => {
-  return (
-    <header className="moya__header">
-      <h1>
-        <img src="images/obousan.gif" className="moya__h1_image moya__h1_image_first" alt="obousan"/>
-        MOYAMOYA GUGUTASU
-        <img src="images/samurai.gif" className="moya__h1_image moya__h1_image_last" alt="samurai"/>
-      </h1>
-      <button onClick={login} className={stateMe ? 'hidden' : undefined}>Login</button>
-      <button onClick={logout} className={!stateMe ? 'hidden' : undefined}>Logout</button>
-    </header>
-  )
+class Header extends React.Component {
+  login = (e) => {
+    auth.signInWithPopup(provider);
+  }
+
+  logout = (e) => {
+    auth.signOut();
+  }
+
+  render() {
+    return (
+      <header className="moya__header">
+        <h1>
+          <img src="images/obousan.gif" className="moya__h1_image moya__h1_image_first" alt="obousan"/>
+          MOYAMOYA GUGUTASU
+          <img src="images/samurai.gif" className="moya__h1_image moya__h1_image_last" alt="samurai"/>
+        </h1>
+        <button onClick={this.login} className={this.props.stateMe ? 'hidden' : undefined}>Login</button>
+        <button onClick={this.logout} className={!this.props.stateMe ? 'hidden' : undefined}>Logout</button>
+      </header>
+    )
+  }
 }
 
 export default Header

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {db, auth, fieldValue} from './firebase';
+import {db, auth} from './firebase';
 import Header from '../components/Header';
 import ArticleForm from '../components/Article/ArticleForm';
 import ArticleList from '../components/Article/ArticleList';

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -131,7 +131,6 @@ class App extends React.Component {
             deleteComment={this.deleteComment}
             handleChange={this.handleChange}
             state={this.state}
-            stateMeUid={this.state.me.uid}
             stateMe={this.state.me}
           />
         </section>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -17,29 +17,6 @@ class App extends React.Component {
   }
 
   // Article Methods
-  addArticle = (e) => {
-    e.preventDefault();
-
-    const article = this.state.article
-    if (!article) { return; }
-
-    this._clearState('article');
-    this._focusSubmit();
-
-    const ref = dbCollectionArticles.doc();
-    ref.set({
-      message: article,
-      created: fieldValue.serverTimestamp(),
-      updated: fieldValue.serverTimestamp(),
-      uid: this.state.me ? this.state.me.uid : 'nobody',
-      displayName: this.state.me ? this.state.me.displayName : 'noname'
-    }).then(function(docRef) {
-      console.log(docRef);
-    }).catch(function(error) {
-      console.error("Error adding document: ", error);
-    });
-  }
-
   deleteArticle = (e) => {
     if(window.confirm('本当に削除しますか？')){
       dbCollectionArticles.doc(e.target.value).delete().then(function() {
@@ -144,11 +121,6 @@ class App extends React.Component {
       });
     }
 
-    // addArticle
-    _focusSubmit() {
-      document.getElementById('submit').focus();
-    }
-
     // componentWillMount ()
     _generateCommentsHash(querySnapshot) {
       let comments = {};
@@ -182,9 +154,7 @@ class App extends React.Component {
       return (
         <section className="moya__container">
           <ArticleForm
-            addArticle={this.addArticle}
-            handleChange={this.handleChange}
-            stateArticle={this.state.article}
+            stateMe={this.state.me}
           />
           <ArticleList
             articles={this.state.articles.slice()}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -27,28 +27,6 @@ class App extends React.Component {
     }
   }
 
-  // Comment Methods
-  deleteComment = (e) => {
-    if(window.confirm('本当に削除しますか？')){
-      const commentId = e.target.value;
-      const articleId = e.target.dataset.articleId;
-      const article = dbCollectionArticles.doc(articleId);
-      const comment = dbCollectionComments.doc(commentId);
-
-      comment.delete().then(function() {
-        article.update({
-          deletedCommentAt: fieldValue.serverTimestamp()
-        }).then(function(docRef) {
-          console.log(docRef);
-        }).catch(function(error) {
-          console.error("Error update document: ", error);
-        });
-      }).catch(function(error) {
-        console.error("Error removeing comment: ", error);
-      });
-    }
-  }
-
   // Component Methods
   componentWillMount() {
     auth.onAuthStateChanged(user => {
@@ -114,7 +92,6 @@ class App extends React.Component {
           <ArticleList
             articles={this.state.articles.slice()}
             deleteArticle={this.deleteArticle}
-            deleteComment={this.deleteComment}
             state={this.state}
             stateMe={this.state.me}
           />

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -28,38 +28,6 @@ class App extends React.Component {
   }
 
   // Comment Methods
-  addComment = (e) => {
-    e.preventDefault();
-
-    const articleId = e.target.dataset.articleId;
-    const key = `comment-${articleId}`
-
-    const comment = this.state[key];
-    if (!comment) { return; }
-
-    this._clearState(key);
-
-    const article = dbCollectionArticles.doc(articleId);
-    const ref = dbCollectionComments.doc();
-    ref.set({
-      articleId: articleId,
-      message: comment,
-      created: fieldValue.serverTimestamp(),
-      uid: this.state.me ? this.state.me.uid : 'nobody',
-      displayName: this.state.me ? this.state.me.displayName : 'noname'
-    }).then(function(docRef) {
-      article.update({
-        updated: fieldValue.serverTimestamp()
-      }).then(function(docRef) {
-        console.log(docRef);
-      }).catch(function(error) {
-        console.error("Error update document: ", error);
-      });
-    }).catch(function(error) {
-      console.error("Error adding document: ", error);
-    });
-  }
-
   deleteComment = (e) => {
     if(window.confirm('本当に削除しますか？')){
       const commentId = e.target.value;
@@ -164,6 +132,7 @@ class App extends React.Component {
             handleChange={this.handleChange}
             state={this.state}
             stateMeUid={this.state.me.uid}
+            stateMe={this.state.me}
           />
         </section>
       )

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -17,7 +17,7 @@ class App extends React.Component {
   }
 
   // Component Methods
-  componentWillMount() {
+  componentDidMount() {
     auth.onAuthStateChanged(user => {
       if (user) {
         dbCollectionArticles.orderBy('created').onSnapshot((docSnapShot) => {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {db, auth, provider, fieldValue} from './firebase';
+import {db, auth, fieldValue} from './firebase';
 import Header from '../components/Header';
 import ArticleForm from '../components/Article/ArticleForm';
 import ArticleList from '../components/Article/ArticleList';
@@ -104,15 +104,6 @@ class App extends React.Component {
     }
   }
 
-  // Auth Methods
-  login = (e) => {
-    auth.signInWithPopup(provider);
-  }
-
-  logout = (e) => {
-    auth.signOut();
-  }
-
   // State Methods
   handleChange = (e) => {
     const t = e.target;
@@ -212,7 +203,7 @@ class App extends React.Component {
   render() {
     return (
       <div className="App">
-        <Header login={this.login} logout={this.logout} stateMe={this.state.me}/>
+        <Header stateMe={this.state.me}/>
         {this.state.me && this._renderContent()}
       </div>
     )

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -162,26 +162,15 @@ class App extends React.Component {
     _generateCommentsHash(querySnapshot) {
       let comments = {};
 
-      const commentsArray = this._generateCommentsArray(querySnapshot)
-      commentsArray.forEach(dataComment => {
-        const articleId = dataComment.articleId;
-        if(!comments[articleId]){ comments[articleId] = []; }
-        comments[articleId].push(dataComment);
-      });
-
-      return comments;
-    }
-
-    _generateCommentsArray(querySnapshot) {
-      let dataComments = [];
-
       querySnapshot.forEach(comment_doc => {
         let comment_data = comment_doc.data();
         comment_data.id = comment_doc.id;
-        dataComments.push(comment_data);
+        const articleId = comment_data.articleId;
+        if(!comments[articleId]){ comments[articleId] = []; }
+        comments[articleId].push(comment_data);
       });
 
-      return dataComments;
+      return comments;
     }
 
     _buildArticles(docSnapShot, commentsHash) {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -49,12 +49,6 @@ class App extends React.Component {
     }
   }
 
-  // State Methods
-  handleChange = (e) => {
-    const t = e.target;
-    this.state[t.name] = t.value;
-  }
-
   // Component Methods
   componentWillMount() {
     auth.onAuthStateChanged(user => {
@@ -82,13 +76,6 @@ class App extends React.Component {
   }
 
   // Private Methods
-    // common
-    _clearState(key) {
-      this.setState({[key]: ''}, () => {
-        this.setState({[key]: undefined});
-      });
-    }
-
     // componentWillMount ()
     _generateCommentsHash(querySnapshot) {
       let comments = {};
@@ -127,9 +114,7 @@ class App extends React.Component {
           <ArticleList
             articles={this.state.articles.slice()}
             deleteArticle={this.deleteArticle}
-            addComment={this.addComment}
             deleteComment={this.deleteComment}
-            handleChange={this.handleChange}
             state={this.state}
             stateMe={this.state.me}
           />

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -16,17 +16,6 @@ class App extends React.Component {
     }
   }
 
-  // Article Methods
-  deleteArticle = (e) => {
-    if(window.confirm('本当に削除しますか？')){
-      dbCollectionArticles.doc(e.target.value).delete().then(function() {
-        console.log("Document successfully deleted!");
-      }).catch(function(error) {
-        console.error("Error removeing document: ", error);
-      });
-    }
-  }
-
   // Component Methods
   componentWillMount() {
     auth.onAuthStateChanged(user => {
@@ -91,7 +80,6 @@ class App extends React.Component {
           />
           <ArticleList
             articles={this.state.articles.slice()}
-            deleteArticle={this.deleteArticle}
             state={this.state}
             stateMe={this.state.me}
           />


### PR DESCRIPTION
### コメント取得を効率化
- Firestoreから取得したものを①ループして配列に格納して、その配列を②ループしてハッシュに格納して、と2回ループさせてしまっていた
- ①のループ処理の際に配列に格納せず直接ハッシュに格納するように変更しました。

### app.jsにあったメソッドを各Componentに移行
- Headerにlogin, logoutメソッドを移行
- ArticleFormにaddArticleメソッドを移行
- CommentFormにaddCommentメソッドを移行
- ArticleにdeleteArticleメソッドを移行
- CommentにdeleteCommentメソッドを移行

### componentWillMount()は非推奨なのでcomponentDidMount()に変更
- https://github.com/manimoto881985/moyatasu_js/issues/23

### Formの値をUncontrolled Components使用に変更